### PR TITLE
Simplify commands structure

### DIFF
--- a/.vscode/createCommand.code-snippets
+++ b/.vscode/createCommand.code-snippets
@@ -13,13 +13,12 @@
 		"prefix": "commandImpl",
 		"body": [
 			"export class ${3:Impl} extends ${5:Abstract__Command} implements ${4:interface}{\n",
-			"protected _id: Collection<Snowflake, Snowflake> = new Collection(null);\nprotected _keyword = ``;\nprotected _guide = ``;\nprotected _usage = `${this.keyword}`;\n private constructor() {super()}",
+			"protected _id: Collection<Snowflake, Snowflake> = new Collection(null);\nreadonly keyword = ``;\nreaonly guide = ``;\nreadonly usage = `${this.keyword}`;\n private constructor() {super()}",
 			"static async init(): Promise<$4>{\nconst cmd = new $3();\ncmd._id = await fetchCommandID(cmd.keyword);\nreturn cmd;\n}",
-			"readonly #aliases = this.addKeywordToAliases\n(\n[],this.keyword\n);",
+			"readonly aliases = this.addKeywordToAliases\n(\n[],this.keyword\n);",
 			"getCommandData(guild_id: Snowflake): ApplicationCommandData { return {\nname: this.keyword,\ndescription: this.guide,\ntype: 'CHAT_INPUT'\n}\n}",
 			"async interactiveExecute(interaction: CommandInteraction): Promise<unknown> {\n\n}",
 			"async execute(message: Message, { }: commandLiteral): Promise<unknown> {\n\n}",
-			"getAliases(): string[] {\n\treturn this.#aliases;\n}",
 			"}"
 		],
 		"description": "creates a commands boiler-plate code"

--- a/.vscode/createCommand.code-snippets
+++ b/.vscode/createCommand.code-snippets
@@ -13,8 +13,8 @@
 		"prefix": "commandImpl",
 		"body": [
 			"export class ${3:Impl} extends ${5:Abstract__Command} implements ${4:interface}{\n",
-			"protected _id: Collection<Snowflake, Snowflake> = new Collection(null);\nreadonly keyword = ``;\nreaonly guide = ``;\nreadonly usage = `${this.keyword}`;\n private constructor() {super()}",
-			"static async init(): Promise<$4>{\nconst cmd = new $3();\ncmd._id = await fetchCommandID(cmd.keyword);\nreturn cmd;\n}",
+			"id: Collection<Snowflake, Snowflake> = new Collection(null);\nreadonly keyword = ``;\nreaonly guide = ``;\nreadonly usage = `${this.keyword}`;\n private constructor() {super()}",
+			"static async init(): Promise<$4>{\nconst cmd = new $3();\ncmd.id = await fetchCommandID(cmd.keyword);\nreturn cmd;\n}",
 			"readonly aliases = this.addKeywordToAliases\n(\n[],this.keyword\n);",
 			"getCommandData(guild_id: Snowflake): ApplicationCommandData { return {\nname: this.keyword,\ndescription: this.guide,\ntype: 'CHAT_INPUT'\n}\n}",
 			"async interactiveExecute(interaction: CommandInteraction): Promise<unknown> {\n\n}",

--- a/src/Commands/AbstractCommand.ts
+++ b/src/Commands/AbstractCommand.ts
@@ -3,23 +3,14 @@ import { commandLiteral, CommandScope } from "../Entities/Generic/command";
 import { GenericCommand } from "./GenericCommand";
 
 export abstract class AbstractCommand implements GenericCommand {
-    protected abstract _id: Collection<Snowflake, Snowflake>;
+    readonly id: Collection<Snowflake, Snowflake>;
     readonly aliases: string[];
     readonly abstract keyword: string;
     readonly abstract guide: string;
     readonly abstract usage: string;
     readonly abstract type: CommandScope;
 
-    get id() {
-        return this._id;
-    }
-
-    set id(id) {
-        this._id = id;
-    }
-
     abstract execute(receivedMessage: Message, receivedCommand: commandLiteral): Promise<unknown>;
-
     abstract interactiveExecute(interaction: BaseCommandInteraction): Promise<unknown>;
 
     respond = async (

--- a/src/Commands/AbstractCommand.ts
+++ b/src/Commands/AbstractCommand.ts
@@ -3,7 +3,8 @@ import { commandLiteral, CommandScope } from "../Entities/Generic/command";
 import { GenericCommand } from "./GenericCommand";
 
 export abstract class AbstractCommand implements GenericCommand {
-    readonly id: Collection<Snowflake, Snowflake>;
+    //TODO: protect
+    id: Collection<Snowflake, Snowflake>;
     readonly aliases: string[];
     readonly abstract keyword: string;
     readonly abstract guide: string;

--- a/src/Commands/AbstractCommand.ts
+++ b/src/Commands/AbstractCommand.ts
@@ -4,15 +4,11 @@ import { GenericCommand } from "./GenericCommand";
 
 export abstract class AbstractCommand implements GenericCommand {
     protected abstract _id: Collection<Snowflake, Snowflake>;
-    protected abstract _keyword: string;
-    protected abstract _guide: string;
-    protected abstract _usage: string;
-    protected abstract _type: CommandScope;
-
-    get type() {
-        return this._type;
-    }
-
+    readonly aliases: string[];
+    readonly abstract keyword: string;
+    readonly abstract guide: string;
+    readonly abstract usage: string;
+    readonly abstract type: CommandScope;
 
     get id() {
         return this._id;
@@ -22,23 +18,9 @@ export abstract class AbstractCommand implements GenericCommand {
         this._id = id;
     }
 
-    get keyword() {
-        return this._keyword;
-    }
-
-    get guide() {
-        return this._guide;
-    }
-
-    get usage() {
-        return this._usage;
-    }
-
     abstract execute(receivedMessage: Message, receivedCommand: commandLiteral): Promise<unknown>;
 
     abstract interactiveExecute(interaction: BaseCommandInteraction): Promise<unknown>;
-
-    abstract getAliases(): string[];
 
     respond = async (
         source: Message | BaseCommandInteraction,
@@ -53,7 +35,7 @@ export abstract class AbstractCommand implements GenericCommand {
             source.reply(response)
 
     matchAliases(possibleCommand: string): boolean {
-        return this.getAliases()
+        return this.aliases
             .some((alias: string) => alias === possibleCommand?.toLowerCase());
     }
 

--- a/src/Commands/GenericCommand.ts
+++ b/src/Commands/GenericCommand.ts
@@ -6,7 +6,7 @@ export interface GenericCommand {
      * Key = id,
      * Value = guild_id
      */
-    readonly id: Collection<Snowflake, Snowflake>;
+    id: Collection<Snowflake, Snowflake>;
     readonly aliases: string[];
     readonly keyword: string;
     readonly guide: string;

--- a/src/Commands/GenericCommand.ts
+++ b/src/Commands/GenericCommand.ts
@@ -6,14 +6,14 @@ export interface GenericCommand {
      * Key = id,
      * Value = guild_id
      */
-    id: Collection<Snowflake, Snowflake>;
-    keyword: string;
-    guide: string;
-    usage: string;
-    type: CommandScope;
+    readonly id: Collection<Snowflake, Snowflake>;
+    readonly aliases: string[];
+    readonly keyword: string;
+    readonly guide: string;
+    readonly usage: string;
+    readonly type: CommandScope;
     interactiveExecute(commandInteraction: BaseCommandInteraction): Promise<unknown>;
     execute(receivedMessage: Message, receivedCommand: commandLiteral): Promise<unknown>;
-    getAliases(): string[];
     matchAliases(possibleCommand: string | undefined): boolean;
     respond(source: Message, response: ReplyMessageOptions): Promise<unknown>;
     respond(source: BaseCommandInteraction, response: InteractionReplyOptions): Promise<unknown>;

--- a/src/Commands/Global/AbstractGlobalCommand.ts
+++ b/src/Commands/Global/AbstractGlobalCommand.ts
@@ -5,7 +5,7 @@ import { AbstractCommand } from "../AbstractCommand";
 import { GenericGlobalCommand } from "./GenericGlobalCommand";
 
 export abstract class AbstractGlobalCommand extends AbstractCommand implements GenericGlobalCommand {
-    protected _type = CommandScope.GLOBAL;
+    readonly type = CommandScope.GLOBAL;
     abstract getCommandData(): ApplicationCommandData;
 
 }

--- a/src/Commands/Global/Impl/mockMessageCmdImpl.ts
+++ b/src/Commands/Global/Impl/mockMessageCmdImpl.ts
@@ -8,7 +8,7 @@ import { mockMessageCmd } from '../Interf/mockMessageCmd';
 
 const textOptionLiteral: ApplicationCommandOptionData['name'] = 'text';
 export class MockMessageCmdImpl extends AbstractGlobalCommand implements mockMessageCmd {
-    protected _id: Collection<Snowflake, Snowflake> = new Collection(null);
+    id: Collection<Snowflake, Snowflake> = new Collection(null);
     readonly keyword = `mock`;
     readonly guide = `Mocks text`;
     readonly usage = `${this.keyword} <text>`;
@@ -17,7 +17,7 @@ export class MockMessageCmdImpl extends AbstractGlobalCommand implements mockMes
 
     static async init(): Promise<mockMessageCmd> {
         const cmd = new MockMessageCmdImpl();
-        cmd._id = await fetchCommandID(cmd.keyword);
+        cmd.id = await fetchCommandID(cmd.keyword);
         return cmd;
     }
 

--- a/src/Commands/Global/Impl/mockMessageCmdImpl.ts
+++ b/src/Commands/Global/Impl/mockMessageCmdImpl.ts
@@ -9,9 +9,9 @@ import { mockMessageCmd } from '../Interf/mockMessageCmd';
 const textOptionLiteral: ApplicationCommandOptionData['name'] = 'text';
 export class MockMessageCmdImpl extends AbstractGlobalCommand implements mockMessageCmd {
     protected _id: Collection<Snowflake, Snowflake> = new Collection(null);
-    protected _keyword = `mock`;
-    protected _guide = `Mocks text`;
-    protected _usage = `${this.keyword} <text>`;
+    readonly keyword = `mock`;
+    readonly guide = `Mocks text`;
+    readonly usage = `${this.keyword} <text>`;
 
     private constructor() { super() }
 
@@ -21,7 +21,7 @@ export class MockMessageCmdImpl extends AbstractGlobalCommand implements mockMes
         return cmd;
     }
 
-    readonly #aliases = this.mergeAliases
+    readonly aliases = this.mergeAliases
         (
             ['mock'],
             this.keyword
@@ -54,9 +54,7 @@ export class MockMessageCmdImpl extends AbstractGlobalCommand implements mockMes
             })
     }
 
-    getAliases(): string[] {
-        return this.#aliases;
-    }
+
 
 
 }

--- a/src/Commands/Global/Impl/tictactoeCmdImpl.ts
+++ b/src/Commands/Global/Impl/tictactoeCmdImpl.ts
@@ -51,9 +51,9 @@ const isWin = (board: MessageButton[][]) => {
 export class tictactoeCmdImpl extends AbstractGlobalCommand implements tictactoeCmd {
 
     protected _id: Collection<Snowflake, Snowflake> = new Collection(null);
-    protected _keyword = `tictactoe`;
-    protected _guide = `Spawns a tic-tac-toe board`;
-    protected _usage = `${this.keyword}`;
+    readonly keyword = `tictactoe`;
+    readonly guide = `Spawns a tic-tac-toe board`;
+    readonly usage = `${this.keyword}`;
     private constructor() { super() }
 
     static async init(): Promise<tictactoeCmd> {
@@ -62,7 +62,7 @@ export class tictactoeCmdImpl extends AbstractGlobalCommand implements tictactoe
         return cmd;
     }
 
-    readonly #aliases = this.mergeAliases
+    readonly aliases = this.mergeAliases
         (
             ['tictactoe', 'tic-tac-toe', 'triliza', 'τριλιζα'], this.keyword
         );
@@ -186,8 +186,6 @@ export class tictactoeCmdImpl extends AbstractGlobalCommand implements tictactoe
     async execute(message: Message, commandLiteral): Promise<void> {
         return
     }
-    getAliases(): string[] {
-        return this.#aliases;
-    }
+
 
 }

--- a/src/Commands/Global/Impl/tictactoeCmdImpl.ts
+++ b/src/Commands/Global/Impl/tictactoeCmdImpl.ts
@@ -50,7 +50,7 @@ const isWin = (board: MessageButton[][]) => {
 
 export class tictactoeCmdImpl extends AbstractGlobalCommand implements tictactoeCmd {
 
-    protected _id: Collection<Snowflake, Snowflake> = new Collection(null);
+    id: Collection<Snowflake, Snowflake> = new Collection(null);
     readonly keyword = `tictactoe`;
     readonly guide = `Spawns a tic-tac-toe board`;
     readonly usage = `${this.keyword}`;
@@ -58,7 +58,7 @@ export class tictactoeCmdImpl extends AbstractGlobalCommand implements tictactoe
 
     static async init(): Promise<tictactoeCmd> {
         const cmd = new tictactoeCmdImpl();
-        cmd._id = await fetchCommandID(cmd.keyword);
+        cmd.id = await fetchCommandID(cmd.keyword);
         return cmd;
     }
 

--- a/src/Commands/Global/Impl/userNotesCmdImpl.ts
+++ b/src/Commands/Global/Impl/userNotesCmdImpl.ts
@@ -10,7 +10,7 @@ import { userNotesCmd } from '../Interf/userNotesCmd';
 
 export class userNotesCmdImpl extends AbstractGlobalCommand implements userNotesCmd {
 
-    protected _id: Collection<Snowflake, Snowflake> = new Collection(null);
+    id: Collection<Snowflake, Snowflake> = new Collection(null);
     readonly keyword = `notes`;
     readonly guide = `Your personal notes`;
     readonly usage = `${this.keyword} add <note> / remove <index> / edit <index> <note> / clear / show`;
@@ -19,7 +19,7 @@ export class userNotesCmdImpl extends AbstractGlobalCommand implements userNotes
 
     static async init(): Promise<userNotesCmd> {
         const cmd = new userNotesCmdImpl();
-        cmd._id = await fetchCommandID(cmd.keyword);
+        cmd.id = await fetchCommandID(cmd.keyword);
         return cmd;
     }
 

--- a/src/Commands/Global/Impl/userNotesCmdImpl.ts
+++ b/src/Commands/Global/Impl/userNotesCmdImpl.ts
@@ -11,9 +11,9 @@ import { userNotesCmd } from '../Interf/userNotesCmd';
 export class userNotesCmdImpl extends AbstractGlobalCommand implements userNotesCmd {
 
     protected _id: Collection<Snowflake, Snowflake> = new Collection(null);
-    protected _keyword = `notes`;
-    protected _guide = `Your personal notes`;
-    protected _usage = `${this.keyword} add <note> / remove <index> / edit <index> <note> / clear / show`;
+    readonly keyword = `notes`;
+    readonly guide = `Your personal notes`;
+    readonly usage = `${this.keyword} add <note> / remove <index> / edit <index> <note> / clear / show`;
 
     private constructor() { super() }
 
@@ -24,7 +24,7 @@ export class userNotesCmdImpl extends AbstractGlobalCommand implements userNotes
     }
 
 
-    readonly #aliases = this.mergeAliases
+    readonly aliases = this.mergeAliases
         (
             ['notes', 'note', 'mynotes', 'my_notes'],
             this.keyword
@@ -189,9 +189,7 @@ export class userNotesCmdImpl extends AbstractGlobalCommand implements userNotes
         }
     }
 
-    getAliases(): string[] {
-        return this.#aliases;
-    }
+
 
 
 }

--- a/src/Commands/Guild/AbstractGuildCommand.ts
+++ b/src/Commands/Guild/AbstractGuildCommand.ts
@@ -5,7 +5,7 @@ import { AbstractCommand } from "../AbstractCommand";
 import { GenericGuildCommand } from "./GenericGuildCommand";
 
 export abstract class AbstractGuildCommand extends AbstractCommand implements GenericGuildCommand {
-    protected _type = CommandScope.GUILD;
+    readonly type = CommandScope.GUILD;
 
     abstract getCommandData(guildID: Snowflake): ApplicationCommandData;
 }

--- a/src/Commands/Guild/Impl/KEP_adminCmdImpl.ts
+++ b/src/Commands/Guild/Impl/KEP_adminCmdImpl.ts
@@ -9,7 +9,7 @@ const [onLiteral, offLiteral] = ["on", "off"];
 
 export class KEP_adminCmdImpl extends AbstractGuildCommand implements KEP_adminCmd {
 
-    protected _id: Collection<Snowflake, Snowflake> = new Collection(null);
+    id: Collection<Snowflake, Snowflake> = new Collection(null);
     readonly keyword = `admin`;
     readonly guide = `Enables/Disables ADMIN permission`;
     readonly usage = `${this.keyword}`;
@@ -18,7 +18,7 @@ export class KEP_adminCmdImpl extends AbstractGuildCommand implements KEP_adminC
 
     static async init(): Promise<KEP_adminCmd> {
         const cmd = new KEP_adminCmdImpl();
-        cmd._id = await fetchCommandID(cmd.keyword);
+        cmd.id = await fetchCommandID(cmd.keyword);
         return cmd;
     }
 

--- a/src/Commands/Guild/Impl/KEP_adminCmdImpl.ts
+++ b/src/Commands/Guild/Impl/KEP_adminCmdImpl.ts
@@ -10,9 +10,9 @@ const [onLiteral, offLiteral] = ["on", "off"];
 export class KEP_adminCmdImpl extends AbstractGuildCommand implements KEP_adminCmd {
 
     protected _id: Collection<Snowflake, Snowflake> = new Collection(null);
-    protected _keyword = `admin`;
-    protected _guide = `Enables/Disables ADMIN permission`;
-    protected _usage = `${this.keyword}`;
+    readonly keyword = `admin`;
+    readonly guide = `Enables/Disables ADMIN permission`;
+    readonly usage = `${this.keyword}`;
 
     private constructor() { super() }
 
@@ -22,9 +22,9 @@ export class KEP_adminCmdImpl extends AbstractGuildCommand implements KEP_adminC
         return cmd;
     }
 
-    readonly #aliases = this.mergeAliases
+    readonly aliases = this.mergeAliases
         (
-            ['adm', 'admin'], this._keyword
+            ['adm', 'admin'], this.keyword
         );
 
 
@@ -82,9 +82,7 @@ export class KEP_adminCmdImpl extends AbstractGuildCommand implements KEP_adminC
         }
     }
 
-    getAliases(): string[] {
-        return this.#aliases;
-    }
+
 
 
 }

--- a/src/Commands/Guild/Impl/KEP_announceCmdImpl.ts
+++ b/src/Commands/Guild/Impl/KEP_announceCmdImpl.ts
@@ -10,9 +10,9 @@ const contentLiteral = `content`
 export class KEP_announceCmdImpl extends AbstractGuildCommand implements KEP_announceCmd {
 
     protected _id: Collection<Snowflake, Snowflake> = new Collection(null);
-    protected _keyword = `announce`;
-    protected _guide = `Ανακοινώνει ένα μήνυμα στα νέα-ενημερώσεις`;
-    protected _usage = `${this.keyword} <message> [<roles>]`;
+    readonly keyword = `announce`;
+    readonly guide = `Ανακοινώνει ένα μήνυμα στα νέα-ενημερώσεις`;
+    readonly usage = `${this.keyword} <message> [<roles>]`;
     private constructor() {
         super()
     }
@@ -22,7 +22,7 @@ export class KEP_announceCmdImpl extends AbstractGuildCommand implements KEP_ann
         cmd._id = await fetchCommandID(cmd.keyword);
         return cmd;
     }
-    readonly #aliases = this.mergeAliases
+    readonly aliases = this.mergeAliases
         (
             ['announce', 'ann'], this.keyword
         );
@@ -128,8 +128,6 @@ export class KEP_announceCmdImpl extends AbstractGuildCommand implements KEP_ann
         return message.reply(`Χρησιμοποιείτε την εντολή ως slash command \`/${this.keyword}\` ώστε να μπορείτε να δηλώσετε και ρόλους για ping`);
     }
 
-    getAliases(): string[] {
-        return this.#aliases;
-    }
+
 
 }

--- a/src/Commands/Guild/Impl/KEP_announceCmdImpl.ts
+++ b/src/Commands/Guild/Impl/KEP_announceCmdImpl.ts
@@ -9,7 +9,7 @@ import { KEP_announceCmd } from "../Interf/KEP_announceCmd";
 const contentLiteral = `content`
 export class KEP_announceCmdImpl extends AbstractGuildCommand implements KEP_announceCmd {
 
-    protected _id: Collection<Snowflake, Snowflake> = new Collection(null);
+    id: Collection<Snowflake, Snowflake> = new Collection(null);
     readonly keyword = `announce`;
     readonly guide = `Ανακοινώνει ένα μήνυμα στα νέα-ενημερώσεις`;
     readonly usage = `${this.keyword} <message> [<roles>]`;
@@ -19,7 +19,7 @@ export class KEP_announceCmdImpl extends AbstractGuildCommand implements KEP_ann
 
     static async init(): Promise<KEP_announceCmd> {
         const cmd = new KEP_announceCmdImpl();
-        cmd._id = await fetchCommandID(cmd.keyword);
+        cmd.id = await fetchCommandID(cmd.keyword);
         return cmd;
     }
     readonly aliases = this.mergeAliases

--- a/src/Commands/Guild/Impl/KEP_courseCmdImpl.ts
+++ b/src/Commands/Guild/Impl/KEP_courseCmdImpl.ts
@@ -14,16 +14,16 @@ const [codeLiteral, nameLiteral, semesterLiteral] = ["code", "name", "semester"]
 export class KEP_courseCmdImpl extends AbstractGuildCommand implements KEP_courseCmd {
 
     protected _id: Collection<Snowflake, Snowflake> = new Collection(null);
-    protected _keyword = `course`;
-    protected _guide = `Διαχειρίζεται τα μαθήματα στη ΒΔ`;
-    protected _usage = `${this.keyword} create <code> <name> <semester> | delete <code> | list`;
+    readonly keyword = `course`;
+    readonly guide = `Διαχειρίζεται τα μαθήματα στη ΒΔ`;
+    readonly usage = `${this.keyword} create <code> <name> <semester> | delete <code> | list`;
     private constructor() { super() }
     static async init(): Promise<KEP_courseCmd> {
         const cmd = new KEP_courseCmdImpl();
         cmd._id = await fetchCommandID(cmd.keyword);
         return cmd;
     }
-    readonly #aliases = this.mergeAliases
+    readonly aliases = this.mergeAliases
         (
             ["courses"], this.keyword
         );
@@ -209,8 +209,6 @@ export class KEP_courseCmdImpl extends AbstractGuildCommand implements KEP_cours
             return message.reply("`MANAGE_GUILD` permissions required")
         return message.reply(`Παρακαλώ χρησιμοποιείστε Slash Command \`/${this.usage}\``)
     }
-    getAliases(): string[] {
-        return this.#aliases;
-    }
+
 
 }

--- a/src/Commands/Guild/Impl/KEP_courseCmdImpl.ts
+++ b/src/Commands/Guild/Impl/KEP_courseCmdImpl.ts
@@ -13,14 +13,14 @@ const [createLiteral, deleteLiteral, listLiteral] = ["create", "delete", "list"]
 const [codeLiteral, nameLiteral, semesterLiteral] = ["code", "name", "semester"];
 export class KEP_courseCmdImpl extends AbstractGuildCommand implements KEP_courseCmd {
 
-    protected _id: Collection<Snowflake, Snowflake> = new Collection(null);
+    id: Collection<Snowflake, Snowflake> = new Collection(null);
     readonly keyword = `course`;
     readonly guide = `Διαχειρίζεται τα μαθήματα στη ΒΔ`;
     readonly usage = `${this.keyword} create <code> <name> <semester> | delete <code> | list`;
     private constructor() { super() }
     static async init(): Promise<KEP_courseCmd> {
         const cmd = new KEP_courseCmdImpl();
-        cmd._id = await fetchCommandID(cmd.keyword);
+        cmd.id = await fetchCommandID(cmd.keyword);
         return cmd;
     }
     readonly aliases = this.mergeAliases

--- a/src/Commands/Guild/Impl/KEP_courseTeacherCmdImpl.ts
+++ b/src/Commands/Guild/Impl/KEP_courseTeacherCmdImpl.ts
@@ -12,16 +12,16 @@ const [codeLiteral, usernameLiteral] = ['code', 'username'];
 export class KEP_courseTeacherCmdImpl extends AbstractGuildCommand implements KEP_courseTeacherCmd {
 
     protected _id: Collection<Snowflake, Snowflake> = new Collection(null);
-    protected _keyword = `course_teacher`;
-    protected _guide = `Συσχέτιση μεταξύ μαθήματος και καθηγητή`;
-    protected _usage = `${this.keyword} link | unlink <course_code> <teacher_username> | list`;
+    readonly keyword = `course_teacher`;
+    readonly guide = `Συσχέτιση μεταξύ μαθήματος και καθηγητή`;
+    readonly usage = `${this.keyword} link | unlink <course_code> <teacher_username> | list`;
     private constructor() { super() }
     static async init(): Promise<KEP_courseTeacherCmd> {
         const cmd = new KEP_courseTeacherCmdImpl();
         cmd._id = await fetchCommandID(cmd.keyword);
         return cmd;
     }
-    readonly #aliases = this.mergeAliases
+    readonly aliases = this.mergeAliases
         (
             ["courseteacher", "teachercourse", "teacher_course", "course_teacher"], this.keyword
         );
@@ -95,9 +95,7 @@ export class KEP_courseTeacherCmdImpl extends AbstractGuildCommand implements KE
         return handleRequest(message, arg1, arg2, arg3, this.usage);
     }
 
-    getAliases(): string[] {
-        return this.#aliases;
-    }
+
 
 
 }

--- a/src/Commands/Guild/Impl/KEP_courseTeacherCmdImpl.ts
+++ b/src/Commands/Guild/Impl/KEP_courseTeacherCmdImpl.ts
@@ -11,14 +11,14 @@ const [linkLiteral, unlinkLiteral, listLiteral] = ['link', 'unlink', 'list'];
 const [codeLiteral, usernameLiteral] = ['code', 'username'];
 export class KEP_courseTeacherCmdImpl extends AbstractGuildCommand implements KEP_courseTeacherCmd {
 
-    protected _id: Collection<Snowflake, Snowflake> = new Collection(null);
+    id: Collection<Snowflake, Snowflake> = new Collection(null);
     readonly keyword = `course_teacher`;
     readonly guide = `Συσχέτιση μεταξύ μαθήματος και καθηγητή`;
     readonly usage = `${this.keyword} link | unlink <course_code> <teacher_username> | list`;
     private constructor() { super() }
     static async init(): Promise<KEP_courseTeacherCmd> {
         const cmd = new KEP_courseTeacherCmdImpl();
-        cmd._id = await fetchCommandID(cmd.keyword);
+        cmd.id = await fetchCommandID(cmd.keyword);
         return cmd;
     }
     readonly aliases = this.mergeAliases

--- a/src/Commands/Guild/Impl/KEP_dataCmdImpl.ts
+++ b/src/Commands/Guild/Impl/KEP_dataCmdImpl.ts
@@ -8,7 +8,7 @@ import { KEP_dataCmd } from "../Interf/KEP_dataCmd";
 
 export class KEP_dataCmdImpl extends AbstractGuildCommand implements KEP_dataCmd {
 
-    protected _id: Collection<Snowflake, Snowflake> = new Collection(null);
+    id: Collection<Snowflake, Snowflake> = new Collection(null);
     readonly keyword = `data`;
     readonly guide = `Εμφανίζει λεπτομέρειες για συγκεκριμένο μέλος`;
     readonly usage = `${this.keyword} (am <am> | member <member>)`;
@@ -17,7 +17,7 @@ export class KEP_dataCmdImpl extends AbstractGuildCommand implements KEP_dataCmd
 
     static async init(): Promise<KEP_dataCmd> {
         const cmd = new KEP_dataCmdImpl();
-        cmd._id = await fetchCommandID(cmd.keyword);
+        cmd.id = await fetchCommandID(cmd.keyword);
         return cmd;
     }
 

--- a/src/Commands/Guild/Impl/KEP_dataCmdImpl.ts
+++ b/src/Commands/Guild/Impl/KEP_dataCmdImpl.ts
@@ -9,9 +9,9 @@ import { KEP_dataCmd } from "../Interf/KEP_dataCmd";
 export class KEP_dataCmdImpl extends AbstractGuildCommand implements KEP_dataCmd {
 
     protected _id: Collection<Snowflake, Snowflake> = new Collection(null);
-    protected _keyword = `data`;
-    protected _guide = `Εμφανίζει λεπτομέρειες για συγκεκριμένο μέλος`;
-    protected _usage = `${this.keyword} (am <am> | member <member>)`;
+    readonly keyword = `data`;
+    readonly guide = `Εμφανίζει λεπτομέρειες για συγκεκριμένο μέλος`;
+    readonly usage = `${this.keyword} (am <am> | member <member>)`;
 
     private constructor() { super() }
 
@@ -21,7 +21,7 @@ export class KEP_dataCmdImpl extends AbstractGuildCommand implements KEP_dataCmd
         return cmd;
     }
 
-    readonly #aliases = this.mergeAliases
+    readonly aliases = this.mergeAliases
         (
             ["data", "d"], this.keyword
         );
@@ -82,9 +82,7 @@ export class KEP_dataCmdImpl extends AbstractGuildCommand implements KEP_dataCmd
         return message.reply("Για λόγους ασφαλείας, χρησιμοποιείστε **Slash Command** `/data`")
     }
 
-    getAliases(): string[] {
-        return this.#aliases;
-    }
+
 
 }
 

--- a/src/Commands/Guild/Impl/KEP_driveCmdImpl.ts
+++ b/src/Commands/Guild/Impl/KEP_driveCmdImpl.ts
@@ -19,14 +19,14 @@ const enabledHours = [3, 6, 12];
 
 export class KEP_driveCmdImpl extends AbstractGuildCommand implements KEP_driveCmd {
 
-    protected _id: Collection<Snowflake, Snowflake> = new Collection(null);
+    id: Collection<Snowflake, Snowflake> = new Collection(null);
     readonly keyword = `drive`;
     readonly guide = `Λειτουργίες που αφορούν το dai archive`;
     readonly usage = `${this.keyword} register`;
     private constructor() { super() }
     static async init(): Promise<KEP_driveCmd> {
         const cmd = new KEP_driveCmdImpl();
-        cmd._id = await fetchCommandID(cmd.keyword);
+        cmd.id = await fetchCommandID(cmd.keyword);
         return cmd;
     }
     readonly aliases = this.mergeAliases

--- a/src/Commands/Guild/Impl/KEP_driveCmdImpl.ts
+++ b/src/Commands/Guild/Impl/KEP_driveCmdImpl.ts
@@ -20,16 +20,16 @@ const enabledHours = [3, 6, 12];
 export class KEP_driveCmdImpl extends AbstractGuildCommand implements KEP_driveCmd {
 
     protected _id: Collection<Snowflake, Snowflake> = new Collection(null);
-    protected _keyword = `drive`;
-    protected _guide = `Λειτουργίες που αφορούν το dai archive`;
-    protected _usage = `${this.keyword} register`;
+    readonly keyword = `drive`;
+    readonly guide = `Λειτουργίες που αφορούν το dai archive`;
+    readonly usage = `${this.keyword} register`;
     private constructor() { super() }
     static async init(): Promise<KEP_driveCmd> {
         const cmd = new KEP_driveCmdImpl();
         cmd._id = await fetchCommandID(cmd.keyword);
         return cmd;
     }
-    readonly #aliases = this.mergeAliases
+    readonly aliases = this.mergeAliases
         (
             ["drive", "gdrive"], this.keyword
         );
@@ -84,9 +84,7 @@ export class KEP_driveCmdImpl extends AbstractGuildCommand implements KEP_driveC
         return message.reply("Παρακαλώ χρησιμοποιείστε Slash Command. Πληκτρολογήστε `/drive` για περισσότερα");
     }
 
-    getAliases(): string[] {
-        return this.#aliases;
-    }
+
 
 
 }

--- a/src/Commands/Guild/Impl/KEP_eventsCmdImpl.ts
+++ b/src/Commands/Guild/Impl/KEP_eventsCmdImpl.ts
@@ -21,7 +21,7 @@ const lectureLiteral = "lecture";
 const examLiteral = "exam";
 export class KEP_eventsCmdImpl extends AbstractGuildCommand implements KEP_eventsCmd {
 
-    protected _id: Collection<Snowflake, Snowflake> = new Collection(null);
+    id: Collection<Snowflake, Snowflake> = new Collection(null);
     readonly keyword = `calendar_events`;
     readonly guide = `Διαχειρίζεται τα events του Google Calendar`;
     readonly usage = `${this.keyword} ${refreshLiteral}} | ${registerLiteral} <${urlOption}> <${fieldOption}>`;
@@ -29,7 +29,7 @@ export class KEP_eventsCmdImpl extends AbstractGuildCommand implements KEP_event
 
     static async init(): Promise<KEP_eventsCmd> {
         const cmd = new KEP_eventsCmdImpl();
-        cmd._id = await fetchCommandID(cmd.keyword);
+        cmd.id = await fetchCommandID(cmd.keyword);
         return cmd;
     }
 

--- a/src/Commands/Guild/Impl/KEP_eventsCmdImpl.ts
+++ b/src/Commands/Guild/Impl/KEP_eventsCmdImpl.ts
@@ -22,9 +22,9 @@ const examLiteral = "exam";
 export class KEP_eventsCmdImpl extends AbstractGuildCommand implements KEP_eventsCmd {
 
     protected _id: Collection<Snowflake, Snowflake> = new Collection(null);
-    protected _keyword = `calendar_events`;
-    protected _guide = `Διαχειρίζεται τα events του Google Calendar`;
-    protected _usage = `${this.keyword} ${refreshLiteral}} | ${registerLiteral} <${urlOption}> <${fieldOption}>`;
+    readonly keyword = `calendar_events`;
+    readonly guide = `Διαχειρίζεται τα events του Google Calendar`;
+    readonly usage = `${this.keyword} ${refreshLiteral}} | ${registerLiteral} <${urlOption}> <${fieldOption}>`;
     private constructor() { super() }
 
     static async init(): Promise<KEP_eventsCmd> {
@@ -33,7 +33,7 @@ export class KEP_eventsCmdImpl extends AbstractGuildCommand implements KEP_event
         return cmd;
     }
 
-    readonly #aliases = this.mergeAliases
+    readonly aliases = this.mergeAliases
         (
             ["event"], this.keyword
         );
@@ -91,9 +91,7 @@ export class KEP_eventsCmdImpl extends AbstractGuildCommand implements KEP_event
         return message.reply("Παρακαλώ χρησιμοποιείστε Slash Command\n" + this.usage)
     }
 
-    getAliases(): string[] {
-        return this.#aliases;
-    }
+
 
     async handleRequest(interaction: CommandInteraction, subcommand: string) {
         const member = interaction.member instanceof GuildMember ?

--- a/src/Commands/Guild/Impl/KEP_infoCmdImpl.ts
+++ b/src/Commands/Guild/Impl/KEP_infoCmdImpl.ts
@@ -11,9 +11,9 @@ const targetLiteral: ApplicationCommandOptionData['name'] = "target"
 export class KEP_infoCmdImpl extends AbstractGuildCommand implements KEP_infoCmd {
 
     protected _id: Collection<Snowflake, Snowflake> = new Collection(null);
-    protected _keyword = `info`;
-    protected _guide = `Εμφανίζει διάφορες πληροφορίες σχετικά με τη σχολή`;
-    protected _usage = `${this.keyword} <πληροφορία>`;
+    readonly keyword = `info`;
+    readonly guide = `Εμφανίζει διάφορες πληροφορίες σχετικά με τη σχολή`;
+    readonly usage = `${this.keyword} <πληροφορία>`;
 
     private constructor() { super() }
 
@@ -22,7 +22,7 @@ export class KEP_infoCmdImpl extends AbstractGuildCommand implements KEP_infoCmd
         cmd._id = await fetchCommandID(cmd.keyword);
         return cmd;
     }
-    readonly #aliases = this.mergeAliases
+    readonly aliases = this.mergeAliases
         (
             ["info", "i"], this.keyword
         );
@@ -64,9 +64,7 @@ export class KEP_infoCmdImpl extends AbstractGuildCommand implements KEP_infoCmd
         return message.reply(i);
     }
 
-    getAliases(): string[] {
-        return this.#aliases;
-    }
+
 
 
 }

--- a/src/Commands/Guild/Impl/KEP_infoCmdImpl.ts
+++ b/src/Commands/Guild/Impl/KEP_infoCmdImpl.ts
@@ -10,7 +10,7 @@ const targetLiteral: ApplicationCommandOptionData['name'] = "target"
 
 export class KEP_infoCmdImpl extends AbstractGuildCommand implements KEP_infoCmd {
 
-    protected _id: Collection<Snowflake, Snowflake> = new Collection(null);
+    id: Collection<Snowflake, Snowflake> = new Collection(null);
     readonly keyword = `info`;
     readonly guide = `Εμφανίζει διάφορες πληροφορίες σχετικά με τη σχολή`;
     readonly usage = `${this.keyword} <πληροφορία>`;
@@ -19,7 +19,7 @@ export class KEP_infoCmdImpl extends AbstractGuildCommand implements KEP_infoCmd
 
     static async init(): Promise<KEP_infoCmd> {
         const cmd = new KEP_infoCmdImpl();
-        cmd._id = await fetchCommandID(cmd.keyword);
+        cmd.id = await fetchCommandID(cmd.keyword);
         return cmd;
     }
     readonly aliases = this.mergeAliases

--- a/src/Commands/Guild/Impl/KEP_muteCmdImpl.ts
+++ b/src/Commands/Guild/Impl/KEP_muteCmdImpl.ts
@@ -13,16 +13,16 @@ moment.tz("Europe/Athens");
 export class KEP_muteCmdImpl extends AbstractGuildCommand implements KEP_muteCmd {
 
     protected _id: Collection<Snowflake, Snowflake> = new Collection(null);
-    protected _keyword = `mute`;
-    protected _guide = `Mutes a member for certain amount of time`;
-    protected _usage = `${this.keyword} <user> <amount> [reason]`;
+    readonly keyword = `mute`;
+    readonly guide = `Mutes a member for certain amount of time`;
+    readonly usage = `${this.keyword} <user> <amount> [reason]`;
     private constructor() { super() }
     static async init(): Promise<KEP_muteCmd> {
         const cmd = new KEP_muteCmdImpl();
         cmd._id = await fetchCommandID(cmd.keyword);
         return cmd;
     }
-    readonly #aliases = this.mergeAliases
+    readonly aliases = this.mergeAliases
         (
             ["mute", "sks"], this.keyword
         );
@@ -110,9 +110,7 @@ export class KEP_muteCmdImpl extends AbstractGuildCommand implements KEP_muteCmd
         return message.reply("Please use **Slash Command** `/mute`")
     }
 
-    getAliases(): string[] {
-        return this.#aliases;
-    }
+
 
 
 }

--- a/src/Commands/Guild/Impl/KEP_muteCmdImpl.ts
+++ b/src/Commands/Guild/Impl/KEP_muteCmdImpl.ts
@@ -12,14 +12,14 @@ moment.tz("Europe/Athens");
 
 export class KEP_muteCmdImpl extends AbstractGuildCommand implements KEP_muteCmd {
 
-    protected _id: Collection<Snowflake, Snowflake> = new Collection(null);
+    id: Collection<Snowflake, Snowflake> = new Collection(null);
     readonly keyword = `mute`;
     readonly guide = `Mutes a member for certain amount of time`;
     readonly usage = `${this.keyword} <user> <amount> [reason]`;
     private constructor() { super() }
     static async init(): Promise<KEP_muteCmd> {
         const cmd = new KEP_muteCmdImpl();
-        cmd._id = await fetchCommandID(cmd.keyword);
+        cmd.id = await fetchCommandID(cmd.keyword);
         return cmd;
     }
     readonly aliases = this.mergeAliases

--- a/src/Commands/Guild/Impl/KEP_myExamsCmdImpl.ts
+++ b/src/Commands/Guild/Impl/KEP_myExamsCmdImpl.ts
@@ -22,7 +22,7 @@ const fieldBuilder = ((ev: calendar_v3.Schema$Event): EmbedFieldData => ({
 }));
 export class KEP_myExamsCmdImpl extends AbstractGuildCommand implements KEP_myExamsCmd {
 
-    protected _id: Collection<Snowflake, Snowflake> = new Collection(null);
+    id: Collection<Snowflake, Snowflake> = new Collection(null);
     readonly keyword = `myexams`;
     readonly guide = `Εμφανίζει τα επερχόμενα εξεταζόμενα μαθήματά σας`;
     readonly usage = `${this.keyword}`;
@@ -30,7 +30,7 @@ export class KEP_myExamsCmdImpl extends AbstractGuildCommand implements KEP_myEx
 
     static async init(): Promise<KEP_myExamsCmd> {
         const cmd = new KEP_myExamsCmdImpl();
-        cmd._id = await fetchCommandID(cmd.keyword);
+        cmd.id = await fetchCommandID(cmd.keyword);
         return cmd;
     }
 

--- a/src/Commands/Guild/Impl/KEP_myExamsCmdImpl.ts
+++ b/src/Commands/Guild/Impl/KEP_myExamsCmdImpl.ts
@@ -23,9 +23,9 @@ const fieldBuilder = ((ev: calendar_v3.Schema$Event): EmbedFieldData => ({
 export class KEP_myExamsCmdImpl extends AbstractGuildCommand implements KEP_myExamsCmd {
 
     protected _id: Collection<Snowflake, Snowflake> = new Collection(null);
-    protected _keyword = `myexams`;
-    protected _guide = `Εμφανίζει τα επερχόμενα εξεταζόμενα μαθήματά σας`;
-    protected _usage = `${this.keyword}`;
+    readonly keyword = `myexams`;
+    readonly guide = `Εμφανίζει τα επερχόμενα εξεταζόμενα μαθήματά σας`;
+    readonly usage = `${this.keyword}`;
     private constructor() { super() }
 
     static async init(): Promise<KEP_myExamsCmd> {
@@ -34,9 +34,9 @@ export class KEP_myExamsCmdImpl extends AbstractGuildCommand implements KEP_myEx
         return cmd;
     }
 
-    readonly #aliases = this.mergeAliases
+    readonly aliases = this.mergeAliases
         (
-            ['my_exams', 'exams', 'myexams'], this._keyword
+            ['my_exams', 'exams', 'myexams'], this.keyword
         );
 
     getCommandData(guild_id: Snowflake): ChatInputApplicationCommandData {
@@ -55,9 +55,7 @@ export class KEP_myExamsCmdImpl extends AbstractGuildCommand implements KEP_myEx
         return handleRequest(message);
     }
 
-    getAliases(): string[] {
-        return this.#aliases;
-    }
+
 
 }
 

--- a/src/Commands/Guild/Impl/KEP_myScheduleCmdImpl.ts
+++ b/src/Commands/Guild/Impl/KEP_myScheduleCmdImpl.ts
@@ -20,14 +20,14 @@ const fieldBuilder = ((ev: calendar_v3.Schema$Event, course: Course): EmbedField
 }));
 export class KEP_myScheduleCmdImpl extends AbstractGuildCommand implements KEP_myScheduleCmd {
 
-    protected _id: Collection<Snowflake, Snowflake> = new Collection(null);
+    id: Collection<Snowflake, Snowflake> = new Collection(null);
     readonly keyword = `myschedule`;
     readonly guide = `Σας εμφανίζει το εβδομαδιαίο σας πρόγραμμα`;
     readonly usage = `${this.keyword}`;
     private constructor() { super() }
     static async init(): Promise<KEP_myScheduleCmd> {
         const cmd = new KEP_myScheduleCmdImpl();
-        cmd._id = await fetchCommandID(cmd.keyword);
+        cmd.id = await fetchCommandID(cmd.keyword);
         return cmd;
     }
     readonly aliases = this.mergeAliases

--- a/src/Commands/Guild/Impl/KEP_myScheduleCmdImpl.ts
+++ b/src/Commands/Guild/Impl/KEP_myScheduleCmdImpl.ts
@@ -21,18 +21,18 @@ const fieldBuilder = ((ev: calendar_v3.Schema$Event, course: Course): EmbedField
 export class KEP_myScheduleCmdImpl extends AbstractGuildCommand implements KEP_myScheduleCmd {
 
     protected _id: Collection<Snowflake, Snowflake> = new Collection(null);
-    protected _keyword = `myschedule`;
-    protected _guide = `Σας εμφανίζει το εβδομαδιαίο σας πρόγραμμα`;
-    protected _usage = `${this.keyword}`;
+    readonly keyword = `myschedule`;
+    readonly guide = `Σας εμφανίζει το εβδομαδιαίο σας πρόγραμμα`;
+    readonly usage = `${this.keyword}`;
     private constructor() { super() }
     static async init(): Promise<KEP_myScheduleCmd> {
         const cmd = new KEP_myScheduleCmdImpl();
         cmd._id = await fetchCommandID(cmd.keyword);
         return cmd;
     }
-    readonly #aliases = this.mergeAliases
+    readonly aliases = this.mergeAliases
         (
-            ["my_schedule", "schedule"], this._keyword
+            ["my_schedule", "schedule"], this.keyword
         );
 
     getCommandData(guild_id: Snowflake): ChatInputApplicationCommandData {
@@ -78,9 +78,7 @@ export class KEP_myScheduleCmdImpl extends AbstractGuildCommand implements KEP_m
             );
     }
 
-    getAliases(): string[] {
-        return this.#aliases;
-    }
+
 
 
 }

--- a/src/Commands/Guild/Impl/KEP_registrationCmdImpl.ts
+++ b/src/Commands/Guild/Impl/KEP_registrationCmdImpl.ts
@@ -18,14 +18,14 @@ const [email, password] = ['email', 'password']
 
 export class KEP_registrationCmdImpl extends AbstractGuildCommand implements KEP_registrationCmd {
 
-    protected _id: Collection<Snowflake, Snowflake> = new Collection(null);
+    id: Collection<Snowflake, Snowflake> = new Collection(null);
     readonly keyword = `registration`;
     readonly guide = `Εγγραφή στην κοινότητα Εφ. Πληροφορικής`;
     readonly usage = `${this.keyword} register/verify`;
     private constructor() { super() }
     static async init(): Promise<KEP_registrationCmd> {
         const cmd = new KEP_registrationCmdImpl();
-        cmd._id = await fetchCommandID(cmd.keyword);
+        cmd.id = await fetchCommandID(cmd.keyword);
         return cmd;
     }
     readonly aliases = this.mergeAliases

--- a/src/Commands/Guild/Impl/KEP_registrationCmdImpl.ts
+++ b/src/Commands/Guild/Impl/KEP_registrationCmdImpl.ts
@@ -19,18 +19,18 @@ const [email, password] = ['email', 'password']
 export class KEP_registrationCmdImpl extends AbstractGuildCommand implements KEP_registrationCmd {
 
     protected _id: Collection<Snowflake, Snowflake> = new Collection(null);
-    protected _keyword = `registration`;
-    protected _guide = `Εγγραφή στην κοινότητα Εφ. Πληροφορικής`;
-    protected _usage = `${this.keyword} register/verify`;
+    readonly keyword = `registration`;
+    readonly guide = `Εγγραφή στην κοινότητα Εφ. Πληροφορικής`;
+    readonly usage = `${this.keyword} register/verify`;
     private constructor() { super() }
     static async init(): Promise<KEP_registrationCmd> {
         const cmd = new KEP_registrationCmdImpl();
         cmd._id = await fetchCommandID(cmd.keyword);
         return cmd;
     }
-    readonly #aliases = this.mergeAliases
+    readonly aliases = this.mergeAliases
         (
-            [], this._keyword,
+            [], this.keyword,
         );
     getCommandData(guild_id: Snowflake): ChatInputApplicationCommandData {
         return {
@@ -178,9 +178,7 @@ ${pswd}\n
         return message.reply(`Παρακαλώ χρησιμοποιείστε **slash command** πατώντας \`/\` στο κανάλι <#${kepChannels.registration}> και επιλέγοντας \`/registration register\``);
     }
 
-    getAliases(): string[] {
-        return this.#aliases;
-    }
+
 
 
 }

--- a/src/Commands/Guild/Impl/KEP_surveillanceCmdImpl.ts
+++ b/src/Commands/Guild/Impl/KEP_surveillanceCmdImpl.ts
@@ -9,16 +9,16 @@ import { KEP_surveillanceCmd } from "../Interf/KEP_surveillanceCmd";
 export class KEP_surveillanceCmdImpl extends AbstractGuildCommand implements KEP_surveillanceCmd {
 
     protected _id: Collection<Snowflake, Snowflake> = new Collection(null);
-    protected _keyword = `surveillance`;
-    protected _guide = `(Ξε)κλειδώνει όλα τα κανάλια μαθημάτων`;
-    protected _usage = `${this.keyword}`;
+    readonly keyword = `surveillance`;
+    readonly guide = `(Ξε)κλειδώνει όλα τα κανάλια μαθημάτων`;
+    readonly usage = `${this.keyword}`;
     private constructor() { super() }
     static async init(): Promise<KEP_surveillanceCmd> {
         const cmd = new KEP_surveillanceCmdImpl();
         cmd._id = await fetchCommandID(cmd.keyword);
         return cmd;
     }
-    readonly #aliases = this.mergeAliases
+    readonly aliases = this.mergeAliases
         (
             ["επιτήρηση", "επιτηρηση", "epitirisi", "epithrhsh"], this.keyword
         );
@@ -46,8 +46,6 @@ export class KEP_surveillanceCmdImpl extends AbstractGuildCommand implements KEP
             member.roles.remove(role) : member.roles.add(role))
             .catch(err => message.reply(err.toString()))
     }
-    getAliases(): string[] {
-        return this.#aliases;
-    }
+
 
 }

--- a/src/Commands/Guild/Impl/KEP_surveillanceCmdImpl.ts
+++ b/src/Commands/Guild/Impl/KEP_surveillanceCmdImpl.ts
@@ -8,14 +8,14 @@ import { KEP_surveillanceCmd } from "../Interf/KEP_surveillanceCmd";
 
 export class KEP_surveillanceCmdImpl extends AbstractGuildCommand implements KEP_surveillanceCmd {
 
-    protected _id: Collection<Snowflake, Snowflake> = new Collection(null);
+    id: Collection<Snowflake, Snowflake> = new Collection(null);
     readonly keyword = `surveillance`;
     readonly guide = `(Ξε)κλειδώνει όλα τα κανάλια μαθημάτων`;
     readonly usage = `${this.keyword}`;
     private constructor() { super() }
     static async init(): Promise<KEP_surveillanceCmd> {
         const cmd = new KEP_surveillanceCmdImpl();
-        cmd._id = await fetchCommandID(cmd.keyword);
+        cmd.id = await fetchCommandID(cmd.keyword);
         return cmd;
     }
     readonly aliases = this.mergeAliases

--- a/src/Commands/Guild/Impl/KEP_teacherCmdImpl.ts
+++ b/src/Commands/Guild/Impl/KEP_teacherCmdImpl.ts
@@ -22,14 +22,14 @@ const [
     ];
 export class KEP_teacherCmdImpl extends AbstractGuildCommand implements KEP_teacherCmd {
 
-    protected _id: Collection<Snowflake, Snowflake> = new Collection(null);
+    id: Collection<Snowflake, Snowflake> = new Collection(null);
     readonly keyword = `teacher`;
     readonly guide = `Διαχειρίζεται τους καθηγητές στη ΒΔ`;
     readonly usage = `${this.keyword} create <username> <full_name> <phone_number>, [picture_url], [website] | delete <username> | list`;
     private constructor() { super() }
     static async init(): Promise<KEP_teacherCmd> {
         const cmd = new KEP_teacherCmdImpl();
-        cmd._id = await fetchCommandID(cmd.keyword);
+        cmd.id = await fetchCommandID(cmd.keyword);
         return cmd;
     }
     readonly aliases = this.mergeAliases

--- a/src/Commands/Guild/Impl/KEP_teacherCmdImpl.ts
+++ b/src/Commands/Guild/Impl/KEP_teacherCmdImpl.ts
@@ -23,16 +23,16 @@ const [
 export class KEP_teacherCmdImpl extends AbstractGuildCommand implements KEP_teacherCmd {
 
     protected _id: Collection<Snowflake, Snowflake> = new Collection(null);
-    protected _keyword = `teacher`;
-    protected _guide = `Διαχειρίζεται τους καθηγητές στη ΒΔ`;
-    protected _usage = `${this.keyword} create <username> <full_name> <phone_number>, [picture_url], [website] | delete <username> | list`;
+    readonly keyword = `teacher`;
+    readonly guide = `Διαχειρίζεται τους καθηγητές στη ΒΔ`;
+    readonly usage = `${this.keyword} create <username> <full_name> <phone_number>, [picture_url], [website] | delete <username> | list`;
     private constructor() { super() }
     static async init(): Promise<KEP_teacherCmd> {
         const cmd = new KEP_teacherCmdImpl();
         cmd._id = await fetchCommandID(cmd.keyword);
         return cmd;
     }
-    readonly #aliases = this.mergeAliases
+    readonly aliases = this.mergeAliases
         (
             ["teachers"], this.keyword
         );
@@ -168,8 +168,6 @@ export class KEP_teacherCmdImpl extends AbstractGuildCommand implements KEP_teac
         return message.reply(`Παρακαλώ χρησιμοποιείστε Slash Command \`/${this.usage}\``)
     }
 
-    getAliases(): string[] {
-        return this.#aliases;
-    }
+
 
 }

--- a/src/Commands/Guild/Impl/bookmarkCmdImpl.ts
+++ b/src/Commands/Guild/Impl/bookmarkCmdImpl.ts
@@ -7,9 +7,9 @@ import { bookmarkCmd } from "../Interf/bookmarkCmd";
 export class bookmarkCmdImpl extends AbstractGuildCommand implements bookmarkCmd {
 
     protected _id: Collection<Snowflake, Snowflake> = new Collection(null);
-    protected _keyword = `bookmark`;
-    protected _guide = null;
-    protected _usage = null;
+    readonly keyword = `bookmark`;
+    readonly guide = null;
+    readonly usage = null;
 
     private constructor() { super() }
 
@@ -19,7 +19,7 @@ export class bookmarkCmdImpl extends AbstractGuildCommand implements bookmarkCmd
         return cmd;
     }
 
-    readonly #aliases = this.mergeAliases
+    readonly aliases = this.mergeAliases
         (
             ['bookmark', 'bm'], this.keyword
         );
@@ -58,11 +58,6 @@ export class bookmarkCmdImpl extends AbstractGuildCommand implements bookmarkCmd
             return this.respond(source, { content: response });
         }
     }
-
-    getAliases(): string[] {
-        return this.#aliases;
-    }
-
 }
 
 

--- a/src/Commands/Guild/Impl/bookmarkCmdImpl.ts
+++ b/src/Commands/Guild/Impl/bookmarkCmdImpl.ts
@@ -6,7 +6,7 @@ import { bookmarkCmd } from "../Interf/bookmarkCmd";
 
 export class bookmarkCmdImpl extends AbstractGuildCommand implements bookmarkCmd {
 
-    protected _id: Collection<Snowflake, Snowflake> = new Collection(null);
+    id: Collection<Snowflake, Snowflake> = new Collection(null);
     readonly keyword = `bookmark`;
     readonly guide = null;
     readonly usage = null;
@@ -15,7 +15,7 @@ export class bookmarkCmdImpl extends AbstractGuildCommand implements bookmarkCmd
 
     static async init(): Promise<bookmarkCmd> {
         const cmd = new bookmarkCmdImpl();
-        cmd._id = await fetchCommandID(cmd.keyword);
+        cmd.id = await fetchCommandID(cmd.keyword);
         return cmd;
     }
 

--- a/src/Commands/Guild/Impl/clearMessagesCmdImpl.ts
+++ b/src/Commands/Guild/Impl/clearMessagesCmdImpl.ts
@@ -7,7 +7,7 @@ import { clearMessagesCmd } from "../Interf/clearMessagesCmd";
 const numberOptionLiteral: ApplicationCommandOptionData['name'] = 'number';
 
 export class ClearMessagesCmdImpl extends AbstractGuildCommand implements clearMessagesCmd {
-    protected _id: Collection<Snowflake, Snowflake> = new Collection(null);
+    id: Collection<Snowflake, Snowflake> = new Collection(null);
     readonly keyword = `clear`;
     readonly guide = `Deletes a provided number of recent messages`;
     readonly usage = `${this.keyword} number`;
@@ -15,7 +15,7 @@ export class ClearMessagesCmdImpl extends AbstractGuildCommand implements clearM
 
     static async init(): Promise<clearMessagesCmd> {
         const cmd = new ClearMessagesCmdImpl();
-        cmd._id = await fetchCommandID(cmd.keyword);
+        cmd.id = await fetchCommandID(cmd.keyword);
         return cmd;
     }
 

--- a/src/Commands/Guild/Impl/clearMessagesCmdImpl.ts
+++ b/src/Commands/Guild/Impl/clearMessagesCmdImpl.ts
@@ -8,9 +8,9 @@ const numberOptionLiteral: ApplicationCommandOptionData['name'] = 'number';
 
 export class ClearMessagesCmdImpl extends AbstractGuildCommand implements clearMessagesCmd {
     protected _id: Collection<Snowflake, Snowflake> = new Collection(null);
-    protected _keyword = `clear`;
-    protected _guide = `Deletes a provided number of recent messages`;
-    protected _usage = `${this.keyword} number`;
+    readonly keyword = `clear`;
+    readonly guide = `Deletes a provided number of recent messages`;
+    readonly usage = `${this.keyword} number`;
     private constructor() { super() }
 
     static async init(): Promise<clearMessagesCmd> {
@@ -20,7 +20,7 @@ export class ClearMessagesCmdImpl extends AbstractGuildCommand implements clearM
     }
 
 
-    readonly #aliases = this.mergeAliases
+    readonly aliases = this.mergeAliases
         (
             ['clear', 'clean', 'purge'],
             this.keyword
@@ -104,11 +104,5 @@ export class ClearMessagesCmdImpl extends AbstractGuildCommand implements clearM
         else
             return Promise.reject('Requires `MANAGE_MESSAGES` permission')
     }
-
-    getAliases(): string[] {
-        return this.#aliases;
-    }
-
-
 }
 

--- a/src/Commands/Guild/Impl/commandPermsCmdImpl.ts
+++ b/src/Commands/Guild/Impl/commandPermsCmdImpl.ts
@@ -19,16 +19,16 @@ TODO: support global commands
 export class commandPermsCmdImpl extends AbstractGuildCommand implements commandPermsCmd {
 
     protected _id: Collection<Snowflake, Snowflake> = new Collection(null);
-    protected _keyword = `command_perms`;
-    protected _guide = `Lock/Unlock commands`;
-    protected _usage = `${this.keyword} ${lockLiteral} <command> <role1> [role2...] | ${unlockLiteral} <command>`;
+    readonly keyword = `command_perms`;
+    readonly guide = `Lock/Unlock commands`;
+    readonly usage = `${this.keyword} ${lockLiteral} <command> <role1> [role2...] | ${unlockLiteral} <command>`;
     private constructor() { super() }
     static async init(): Promise<commandPermsCmd> {
         const cmd = new commandPermsCmdImpl();
         cmd._id = await fetchCommandID(cmd.keyword);
         return cmd;
     }
-    readonly #aliases = this.mergeAliases
+    readonly aliases = this.mergeAliases
         (
             [], this.keyword
         );
@@ -162,9 +162,7 @@ export class commandPermsCmdImpl extends AbstractGuildCommand implements command
         return message.reply(`Please use Slash Command \`/${this.usage}\``);
     }
 
-    getAliases(): string[] {
-        return this.#aliases;
-    }
+
 
 
 }

--- a/src/Commands/Guild/Impl/commandPermsCmdImpl.ts
+++ b/src/Commands/Guild/Impl/commandPermsCmdImpl.ts
@@ -18,14 +18,14 @@ TODO: support global commands
 //TODO: include listing perms
 export class commandPermsCmdImpl extends AbstractGuildCommand implements commandPermsCmd {
 
-    protected _id: Collection<Snowflake, Snowflake> = new Collection(null);
+    id: Collection<Snowflake, Snowflake> = new Collection(null);
     readonly keyword = `command_perms`;
     readonly guide = `Lock/Unlock commands`;
     readonly usage = `${this.keyword} ${lockLiteral} <command> <role1> [role2...] | ${unlockLiteral} <command>`;
     private constructor() { super() }
     static async init(): Promise<commandPermsCmd> {
         const cmd = new commandPermsCmdImpl();
-        cmd._id = await fetchCommandID(cmd.keyword);
+        cmd.id = await fetchCommandID(cmd.keyword);
         return cmd;
     }
     readonly aliases = this.mergeAliases

--- a/src/Commands/Guild/Impl/dmMemberCmdImpl.ts
+++ b/src/Commands/Guild/Impl/dmMemberCmdImpl.ts
@@ -16,7 +16,7 @@ const userOptionLiteral: ApplicationCommandOptionData['name'] = 'user';
 const messageOptionLiteral: ApplicationCommandOptionData['name'] = 'message';
 export class DmMemberCmdImpl extends AbstractGuildCommand implements dmMemberCmd {
 
-    protected _id: Collection<Snowflake, Snowflake> = new Collection(null);
+    id: Collection<Snowflake, Snowflake> = new Collection(null);
     readonly keyword = `dm`;
     readonly guide = `Sends DM to a specific member`;
     readonly usage = `${this.keyword} member/username/nickname message`;
@@ -24,7 +24,7 @@ export class DmMemberCmdImpl extends AbstractGuildCommand implements dmMemberCmd
 
     static async init(): Promise<dmMemberCmd> {
         const cmd = new DmMemberCmdImpl();
-        cmd._id = await fetchCommandID(cmd.keyword);
+        cmd.id = await fetchCommandID(cmd.keyword);
         return cmd;
     }
 

--- a/src/Commands/Guild/Impl/dmMemberCmdImpl.ts
+++ b/src/Commands/Guild/Impl/dmMemberCmdImpl.ts
@@ -17,9 +17,9 @@ const messageOptionLiteral: ApplicationCommandOptionData['name'] = 'message';
 export class DmMemberCmdImpl extends AbstractGuildCommand implements dmMemberCmd {
 
     protected _id: Collection<Snowflake, Snowflake> = new Collection(null);
-    protected _keyword = `dm`;
-    protected _guide = `Sends DM to a specific member`;
-    protected _usage = `${this.keyword} member/username/nickname message`;
+    readonly keyword = `dm`;
+    readonly guide = `Sends DM to a specific member`;
+    readonly usage = `${this.keyword} member/username/nickname message`;
     private constructor() { super() }
 
     static async init(): Promise<dmMemberCmd> {
@@ -28,7 +28,7 @@ export class DmMemberCmdImpl extends AbstractGuildCommand implements dmMemberCmd
         return cmd;
     }
 
-    readonly #aliases = this.mergeAliases
+    readonly aliases = this.mergeAliases
         (
             ['directmessage', 'message', 'dm'],
             this.keyword
@@ -131,9 +131,7 @@ export class DmMemberCmdImpl extends AbstractGuildCommand implements dmMemberCmd
             })
     }
 
-    getAliases(): string[] {
-        return this.#aliases;
-    }
+
 
 
 }

--- a/src/Commands/Guild/Impl/editMessageCmdImpl.ts
+++ b/src/Commands/Guild/Impl/editMessageCmdImpl.ts
@@ -13,9 +13,9 @@ const editedMsgOptionLiteral: ApplicationCommandOptionData['name'] = 'edit';
 //* Requires Command Re-Registration  
 export class EditMessageCmdImpl extends AbstractGuildCommand implements editMessageCmd {
     protected _id: Collection<Snowflake, Snowflake> = new Collection(null);
-    protected _keyword = `editmsg`;
-    protected _guide = `Edits a bot's text message`;
-    protected _usage = `${this.keyword} <msg_url> <text>`;
+    readonly keyword = `editmsg`;
+    readonly guide = `Edits a bot's text message`;
+    readonly usage = `${this.keyword} <msg_url> <text>`;
     private constructor() { super() }
 
     static async init(): Promise<editMessageCmd> {
@@ -24,7 +24,7 @@ export class EditMessageCmdImpl extends AbstractGuildCommand implements editMess
         return cmd;
     }
 
-    readonly #aliases = this.mergeAliases
+    readonly aliases = this.mergeAliases
         (
             ['editmessage', 'messageedit', 'messagedit', 'editmsg', 'msgedit'],
             this.keyword
@@ -70,9 +70,7 @@ export class EditMessageCmdImpl extends AbstractGuildCommand implements editMess
         return this.handler(message, arg1, { content: args2 });
     }
 
-    getAliases(): string[] {
-        return this.#aliases;
-    }
+
 
     async handler(source: Message | CommandInteraction, messageURL: Message['url'], newMessageOptions: MessageEditOptions) {
         const [guildId, channelId, messageId] = resolveMessageURL(messageURL);

--- a/src/Commands/Guild/Impl/editMessageCmdImpl.ts
+++ b/src/Commands/Guild/Impl/editMessageCmdImpl.ts
@@ -12,7 +12,7 @@ const editedMsgOptionLiteral: ApplicationCommandOptionData['name'] = 'edit';
 //TODO: use message link for channel and message id
 //* Requires Command Re-Registration  
 export class EditMessageCmdImpl extends AbstractGuildCommand implements editMessageCmd {
-    protected _id: Collection<Snowflake, Snowflake> = new Collection(null);
+    id: Collection<Snowflake, Snowflake> = new Collection(null);
     readonly keyword = `editmsg`;
     readonly guide = `Edits a bot's text message`;
     readonly usage = `${this.keyword} <msg_url> <text>`;
@@ -20,7 +20,7 @@ export class EditMessageCmdImpl extends AbstractGuildCommand implements editMess
 
     static async init(): Promise<editMessageCmd> {
         const cmd = new EditMessageCmdImpl();
-        cmd._id = await fetchCommandID(cmd.keyword);
+        cmd.id = await fetchCommandID(cmd.keyword);
         return cmd;
     }
 

--- a/src/Commands/Guild/Impl/messageChannelCmdImpl.ts
+++ b/src/Commands/Guild/Impl/messageChannelCmdImpl.ts
@@ -9,7 +9,7 @@ const channelOptionLiteral: ApplicationCommandOptionData['name'] = 'channel';
 const msgOptionLiteral: ApplicationCommandOptionData['name'] = 'message';
 
 export class MessageChannelCmdImpl extends AbstractGuildCommand implements messageChannelCmd {
-    protected _id: Collection<Snowflake, Snowflake> = new Collection(null);
+    id: Collection<Snowflake, Snowflake> = new Collection(null);
     readonly keyword = `send`;
     readonly guide = `Messages a specific channel on the guild`;
     readonly usage = `${this.keyword} <channel> <text>`;
@@ -17,7 +17,7 @@ export class MessageChannelCmdImpl extends AbstractGuildCommand implements messa
 
     static async init(): Promise<messageChannelCmd> {
         const cmd = new MessageChannelCmdImpl();
-        cmd._id = await fetchCommandID(cmd.keyword);
+        cmd.id = await fetchCommandID(cmd.keyword);
         return cmd;
     }
 

--- a/src/Commands/Guild/Impl/messageChannelCmdImpl.ts
+++ b/src/Commands/Guild/Impl/messageChannelCmdImpl.ts
@@ -10,9 +10,9 @@ const msgOptionLiteral: ApplicationCommandOptionData['name'] = 'message';
 
 export class MessageChannelCmdImpl extends AbstractGuildCommand implements messageChannelCmd {
     protected _id: Collection<Snowflake, Snowflake> = new Collection(null);
-    protected _keyword = `send`;
-    protected _guide = `Messages a specific channel on the guild`;
-    protected _usage = `${this.keyword} <channel> <text>`;
+    readonly keyword = `send`;
+    readonly guide = `Messages a specific channel on the guild`;
+    readonly usage = `${this.keyword} <channel> <text>`;
     private constructor() { super() }
 
     static async init(): Promise<messageChannelCmd> {
@@ -21,7 +21,7 @@ export class MessageChannelCmdImpl extends AbstractGuildCommand implements messa
         return cmd;
     }
 
-    readonly #aliases = this.mergeAliases
+    readonly aliases = this.mergeAliases
         (
             ['send', 'msgchannel', 'messagechannel', 'message_channel'],
             this.keyword
@@ -84,7 +84,5 @@ export class MessageChannelCmdImpl extends AbstractGuildCommand implements messa
             throw new Error(`Channel not found`);
     }
 
-    getAliases(): string[] {
-        return this.#aliases;
-    }
+
 }

--- a/src/Commands/Guild/Impl/myResponsesCmdImpl.ts
+++ b/src/Commands/Guild/Impl/myResponsesCmdImpl.ts
@@ -15,9 +15,9 @@ const usage = "myresponses add <response> | remove <index> | show";
 export class myResponsesCmdImpl extends AbstractGuildCommand implements myResponsesCmd {
 
     protected _id: Collection<Snowflake, Snowflake> = new Collection(null);
-    protected _keyword = `myresponses`;
-    protected _guide = `Manage your submitted responses`;
-    protected _usage = `${this.keyword}`;
+    readonly keyword = `myresponses`;
+    readonly guide = `Manage your submitted responses`;
+    readonly usage = `${this.keyword}`;
 
     private constructor() { super() }
 
@@ -28,7 +28,7 @@ export class myResponsesCmdImpl extends AbstractGuildCommand implements myRespon
     }
 
 
-    readonly #aliases = this.mergeAliases
+    readonly aliases = this.mergeAliases
         (
             ['myresponses', 'my_responses', 'responses', 'myresp', 'myresps'],
             this.keyword

--- a/src/Commands/Guild/Impl/myResponsesCmdImpl.ts
+++ b/src/Commands/Guild/Impl/myResponsesCmdImpl.ts
@@ -93,9 +93,7 @@ export class myResponsesCmdImpl extends AbstractGuildCommand implements myRespon
 
     }
 
-    getAliases(): string[] {
-        return this.#aliases
-    }
+
 
 
 

--- a/src/Commands/Guild/Impl/myResponsesCmdImpl.ts
+++ b/src/Commands/Guild/Impl/myResponsesCmdImpl.ts
@@ -14,7 +14,7 @@ const response: ApplicationCommandOptionData['name'] = 'response';
 const usage = "myresponses add <response> | remove <index> | show";
 export class myResponsesCmdImpl extends AbstractGuildCommand implements myResponsesCmd {
 
-    protected _id: Collection<Snowflake, Snowflake> = new Collection(null);
+    id: Collection<Snowflake, Snowflake> = new Collection(null);
     readonly keyword = `myresponses`;
     readonly guide = `Manage your submitted responses`;
     readonly usage = `${this.keyword}`;
@@ -23,7 +23,7 @@ export class myResponsesCmdImpl extends AbstractGuildCommand implements myRespon
 
     static async init(): Promise<myResponsesCmd> {
         const cmd = new myResponsesCmdImpl();
-        cmd._id = await fetchCommandID(cmd.keyword);
+        cmd.id = await fetchCommandID(cmd.keyword);
         return cmd;
     }
 

--- a/src/Commands/Guild/Impl/openVoiceCmdImpl.ts
+++ b/src/Commands/Guild/Impl/openVoiceCmdImpl.ts
@@ -7,14 +7,14 @@ import { openVoiceCmd } from "../Interf/openVoiceCmd";
 
 export class openVoiceCmdImpl extends AbstractGuildCommand implements openVoiceCmd {
 
-    protected _id: Collection<Snowflake, Snowflake> = new Collection(null);
+    id: Collection<Snowflake, Snowflake> = new Collection(null);
     readonly keyword = `open-voice`;
     readonly guide = `Unlocks voice for member or role`;
     readonly usage = `${this.keyword} <member | role>`;
     private constructor() { super() }
     static async init(): Promise<openVoiceCmd> {
         const cmd = new openVoiceCmdImpl();
-        cmd._id = await fetchCommandID(cmd.keyword);
+        cmd.id = await fetchCommandID(cmd.keyword);
         return cmd;
     }
     readonly aliases = this.mergeAliases

--- a/src/Commands/Guild/Impl/openVoiceCmdImpl.ts
+++ b/src/Commands/Guild/Impl/openVoiceCmdImpl.ts
@@ -8,16 +8,16 @@ import { openVoiceCmd } from "../Interf/openVoiceCmd";
 export class openVoiceCmdImpl extends AbstractGuildCommand implements openVoiceCmd {
 
     protected _id: Collection<Snowflake, Snowflake> = new Collection(null);
-    protected _keyword = `open-voice`;
-    protected _guide = `Unlocks voice for member or role`;
-    protected _usage = `${this.keyword} <member | role>`;
+    readonly keyword = `open-voice`;
+    readonly guide = `Unlocks voice for member or role`;
+    readonly usage = `${this.keyword} <member | role>`;
     private constructor() { super() }
     static async init(): Promise<openVoiceCmd> {
         const cmd = new openVoiceCmdImpl();
         cmd._id = await fetchCommandID(cmd.keyword);
         return cmd;
     }
-    readonly #aliases = this.mergeAliases
+    readonly aliases = this.mergeAliases
         (
             ["open_voice", "unlock_voice", "unlock-voice"], this.keyword
         );
@@ -64,8 +64,6 @@ export class openVoiceCmdImpl extends AbstractGuildCommand implements openVoiceC
         return message.reply(`Please use slash command => \`/${this.usage}\``);
     }
 
-    getAliases(): string[] {
-        return this.#aliases;
-    }
+
 
 }

--- a/src/Commands/Guild/Impl/pinMessageCmdImpl.ts
+++ b/src/Commands/Guild/Impl/pinMessageCmdImpl.ts
@@ -7,9 +7,9 @@ import { AbstractGuildCommand } from "../AbstractGuildCommand";
 export class PinMessageCmdImpl extends AbstractGuildCommand implements pinMessageCmd {
 
     protected _id: Collection<Snowflake, Snowflake> = new Collection(null);
-    protected _keyword = `pin`;
-    protected _guide = `Pins a message`;
-    protected _usage = `Right click on message => Apps => ${this.keyword}`;
+    readonly keyword = `pin`;
+    readonly guide = `Pins a message`;
+    readonly usage = `Right click on message => Apps => ${this.keyword}`;
     private constructor() { super() }
 
     static async init(): Promise<pinMessageCmd> {
@@ -18,7 +18,7 @@ export class PinMessageCmdImpl extends AbstractGuildCommand implements pinMessag
         return cmd;
     }
 
-    readonly #aliases = this.mergeAliases
+    readonly aliases = this.mergeAliases
         (
             ['pin', 'πιν'],
             this.keyword
@@ -70,9 +70,7 @@ export class PinMessageCmdImpl extends AbstractGuildCommand implements pinMessag
 
     }
 
-    getAliases(): string[] {
-        return this.#aliases;
-    }
+
 
 
 

--- a/src/Commands/Guild/Impl/pinMessageCmdImpl.ts
+++ b/src/Commands/Guild/Impl/pinMessageCmdImpl.ts
@@ -6,7 +6,7 @@ import { AbstractGuildCommand } from "../AbstractGuildCommand";
 
 export class PinMessageCmdImpl extends AbstractGuildCommand implements pinMessageCmd {
 
-    protected _id: Collection<Snowflake, Snowflake> = new Collection(null);
+    id: Collection<Snowflake, Snowflake> = new Collection(null);
     readonly keyword = `pin`;
     readonly guide = `Pins a message`;
     readonly usage = `Right click on message => Apps => ${this.keyword}`;
@@ -14,7 +14,7 @@ export class PinMessageCmdImpl extends AbstractGuildCommand implements pinMessag
 
     static async init(): Promise<pinMessageCmd> {
         const cmd = new PinMessageCmdImpl();
-        cmd._id = await fetchCommandID(cmd.keyword);
+        cmd.id = await fetchCommandID(cmd.keyword);
         return cmd;
     }
 

--- a/src/Commands/Guild/Impl/pollCmdImpl.ts
+++ b/src/Commands/Guild/Impl/pollCmdImpl.ts
@@ -7,7 +7,7 @@ import { pollCmd } from "../Interf/pollCmd";
 const textOptionLiteral: ApplicationCommandOptionData['name'] = 'text';
 export class PollCmdImpl extends AbstractGuildCommand implements pollCmd {
 
-    protected _id: Collection<Snowflake, Snowflake> = new Collection(null);
+    id: Collection<Snowflake, Snowflake> = new Collection(null);
     readonly keyword = `poll`;
     readonly guide = `Creates a simple poll using 👍-👎`;
     readonly usage = `${this.keyword} <text>`;
@@ -15,7 +15,7 @@ export class PollCmdImpl extends AbstractGuildCommand implements pollCmd {
 
     static async init(): Promise<pollCmd> {
         const cmd = new PollCmdImpl();
-        cmd._id = await fetchCommandID(cmd.keyword);
+        cmd.id = await fetchCommandID(cmd.keyword);
         return cmd;
     }
 

--- a/src/Commands/Guild/Impl/pollCmdImpl.ts
+++ b/src/Commands/Guild/Impl/pollCmdImpl.ts
@@ -107,9 +107,7 @@ export class PollCmdImpl extends AbstractGuildCommand implements pollCmd {
             })
     }
 
-    getAliases(): string[] {
-        return this.#aliases
-    }
+
 
 
 }

--- a/src/Commands/Guild/Impl/pollCmdImpl.ts
+++ b/src/Commands/Guild/Impl/pollCmdImpl.ts
@@ -8,9 +8,9 @@ const textOptionLiteral: ApplicationCommandOptionData['name'] = 'text';
 export class PollCmdImpl extends AbstractGuildCommand implements pollCmd {
 
     protected _id: Collection<Snowflake, Snowflake> = new Collection(null);
-    protected _keyword = `poll`;
-    protected _guide = `Creates a simple poll using 👍-👎`;
-    protected _usage = `${this.keyword} <text>`;
+    readonly keyword = `poll`;
+    readonly guide = `Creates a simple poll using 👍-👎`;
+    readonly usage = `${this.keyword} <text>`;
     private constructor() { super() }
 
     static async init(): Promise<pollCmd> {
@@ -19,7 +19,7 @@ export class PollCmdImpl extends AbstractGuildCommand implements pollCmd {
         return cmd;
     }
 
-    readonly #aliases = this.mergeAliases
+    readonly aliases = this.mergeAliases
         (
             ['poll', 'πολλ'],
             this.keyword

--- a/src/Commands/Guild/Impl/settingsCmdImpl.ts
+++ b/src/Commands/Guild/Impl/settingsCmdImpl.ts
@@ -11,16 +11,16 @@ const [voiceOptLiteral, newPrefixOptLiteral] = ["voice_channel", "new_prefix"]
 
 export class settingsCmdImpl extends AbstractGuildCommand implements settingsCmd {
     protected _id: Collection<Snowflake, Snowflake> = new Collection(null);
-    protected _keyword = `settings`;
-    protected _guide = `edits guild settings`;
-    protected _usage = `${this.keyword} nsfw | voice-lobby <channel_id> | prefix [new_prefix]`;
+    readonly keyword = `settings`;
+    readonly guide = `edits guild settings`;
+    readonly usage = `${this.keyword} nsfw | voice-lobby <channel_id> | prefix [new_prefix]`;
     private constructor() { super() }
     static async init(): Promise<settingsCmd> {
         const cmd = new settingsCmdImpl();
         cmd._id = await fetchCommandID(cmd.keyword);
         return cmd;
     }
-    readonly #aliases = this.mergeAliases
+    readonly aliases = this.mergeAliases
         (
             [], this.keyword
         );
@@ -84,9 +84,7 @@ export class settingsCmdImpl extends AbstractGuildCommand implements settingsCmd
         return this.coreHandler(subcommand, message, args);
     }
 
-    getAliases(): string[] {
-        return this.#aliases;
-    }
+
 
 
 

--- a/src/Commands/Guild/Impl/settingsCmdImpl.ts
+++ b/src/Commands/Guild/Impl/settingsCmdImpl.ts
@@ -10,14 +10,14 @@ const [nsfwLiteral, lobbyLiteral, prefixLiteral] = ["nsfw", "voice-lobby", "pref
 const [voiceOptLiteral, newPrefixOptLiteral] = ["voice_channel", "new_prefix"]
 
 export class settingsCmdImpl extends AbstractGuildCommand implements settingsCmd {
-    protected _id: Collection<Snowflake, Snowflake> = new Collection(null);
+    id: Collection<Snowflake, Snowflake> = new Collection(null);
     readonly keyword = `settings`;
     readonly guide = `edits guild settings`;
     readonly usage = `${this.keyword} nsfw | voice-lobby <channel_id> | prefix [new_prefix]`;
     private constructor() { super() }
     static async init(): Promise<settingsCmd> {
         const cmd = new settingsCmdImpl();
-        cmd._id = await fetchCommandID(cmd.keyword);
+        cmd.id = await fetchCommandID(cmd.keyword);
         return cmd;
     }
     readonly aliases = this.mergeAliases

--- a/src/Commands/Guild/Impl/showLogsCmdImpl.ts
+++ b/src/Commands/Guild/Impl/showLogsCmdImpl.ts
@@ -13,9 +13,9 @@ import { showLogsCmd } from "../Interf/showLogsCmd";
 export class ShowLogsCmdImpl extends AbstractGuildCommand implements showLogsCmd {
 
     protected _id: Collection<Snowflake, Snowflake> = new Collection(null);
-    protected _keyword = `logs`;
-    protected _guide = `Prints guilds logs`;
-    protected _usage = `${this.keyword}`;
+    readonly keyword = `logs`;
+    readonly guide = `Prints guilds logs`;
+    readonly usage = `${this.keyword}`;
 
     private constructor() { super() }
 
@@ -25,7 +25,7 @@ export class ShowLogsCmdImpl extends AbstractGuildCommand implements showLogsCmd
         return cmd;
     }
 
-    readonly #aliases = this.mergeAliases
+    readonly aliases = this.mergeAliases
         (
             ['log', 'logs'],
             this.keyword

--- a/src/Commands/Guild/Impl/showLogsCmdImpl.ts
+++ b/src/Commands/Guild/Impl/showLogsCmdImpl.ts
@@ -12,7 +12,7 @@ import { showLogsCmd } from "../Interf/showLogsCmd";
  */
 export class ShowLogsCmdImpl extends AbstractGuildCommand implements showLogsCmd {
 
-    protected _id: Collection<Snowflake, Snowflake> = new Collection(null);
+    id: Collection<Snowflake, Snowflake> = new Collection(null);
     readonly keyword = `logs`;
     readonly guide = `Prints guilds logs`;
     readonly usage = `${this.keyword}`;
@@ -21,7 +21,7 @@ export class ShowLogsCmdImpl extends AbstractGuildCommand implements showLogsCmd
 
     static async init(): Promise<showLogsCmd> {
         const cmd = new ShowLogsCmdImpl();
-        cmd._id = await fetchCommandID(cmd.keyword);
+        cmd.id = await fetchCommandID(cmd.keyword);
         return cmd;
     }
 

--- a/src/Commands/Guild/Impl/showLogsCmdImpl.ts
+++ b/src/Commands/Guild/Impl/showLogsCmdImpl.ts
@@ -134,9 +134,7 @@ export class ShowLogsCmdImpl extends AbstractGuildCommand implements showLogsCmd
         }
     }
 
-    getAliases(): string[] {
-        return this.#aliases
-    }
+
 
 
 

--- a/src/Commands/Guild/Impl/showPermsCmdsImpl.ts
+++ b/src/Commands/Guild/Impl/showPermsCmdsImpl.ts
@@ -10,7 +10,7 @@ const cmdOptionLiteral: ApplicationCommandOptionData['name'] = 'command';
 //TODO: include in command_perms command
 export class ShowPermsCmdsImpl extends AbstractGuildCommand implements showPermsCmd {
 
-    protected _id: Collection<Snowflake, Snowflake> = new Collection(null);
+    id: Collection<Snowflake, Snowflake> = new Collection(null);
     readonly keyword = `perms`;
     readonly guide = `Shows permissions for specific command`;
     readonly usage = `${this.keyword} <command>`;
@@ -19,7 +19,7 @@ export class ShowPermsCmdsImpl extends AbstractGuildCommand implements showPerms
 
     static async init(): Promise<showPermsCmd> {
         const cmd = new ShowPermsCmdsImpl();
-        cmd._id = await fetchCommandID(cmd.keyword);
+        cmd.id = await fetchCommandID(cmd.keyword);
         return cmd;
     }
 

--- a/src/Commands/Guild/Impl/showPermsCmdsImpl.ts
+++ b/src/Commands/Guild/Impl/showPermsCmdsImpl.ts
@@ -11,9 +11,9 @@ const cmdOptionLiteral: ApplicationCommandOptionData['name'] = 'command';
 export class ShowPermsCmdsImpl extends AbstractGuildCommand implements showPermsCmd {
 
     protected _id: Collection<Snowflake, Snowflake> = new Collection(null);
-    protected _keyword = `perms`;
-    protected _guide = `Shows permissions for specific command`;
-    protected _usage = `${this.keyword} <command>`;
+    readonly keyword = `perms`;
+    readonly guide = `Shows permissions for specific command`;
+    readonly usage = `${this.keyword} <command>`;
 
     private constructor() { super() }
 
@@ -23,7 +23,7 @@ export class ShowPermsCmdsImpl extends AbstractGuildCommand implements showPerms
         return cmd;
     }
 
-    readonly #aliases = this.mergeAliases
+    readonly aliases = this.mergeAliases
         (
             ['perms', 'perm', 'showperms', 'show_perms'],
             this.keyword
@@ -81,9 +81,7 @@ export class ShowPermsCmdsImpl extends AbstractGuildCommand implements showPerms
         });
     }
 
-    getAliases(): string[] {
-        return this.#aliases;
-    }
+
 
 
 }

--- a/src/Commands/Guild/Impl/unpinMessageCmdImpl.ts
+++ b/src/Commands/Guild/Impl/unpinMessageCmdImpl.ts
@@ -7,9 +7,9 @@ import { unpinMessageCmd } from "../Interf/unpinMessageCmd";
 export class UnpinMessageCmdImpl extends AbstractGuildCommand implements unpinMessageCmd {
 
     protected _id: Collection<Snowflake, Snowflake> = new Collection(null);
-    protected _keyword = `unpin`;
-    protected _guide = `Unpins a message`;
-    protected _usage = `Right click on message => Apps => ${this.keyword}`;
+    readonly keyword = `unpin`;
+    readonly guide = `Unpins a message`;
+    readonly usage = `Right click on message => Apps => ${this.keyword}`;
 
     private constructor() { super() }
 
@@ -19,7 +19,7 @@ export class UnpinMessageCmdImpl extends AbstractGuildCommand implements unpinMe
         return cmd;
     }
 
-    readonly #aliases = this.mergeAliases
+    readonly aliases = this.mergeAliases
         (
             ['unpin', 'ανπιν'],
             this.keyword
@@ -71,9 +71,7 @@ export class UnpinMessageCmdImpl extends AbstractGuildCommand implements unpinMe
 
     }
 
-    getAliases(): string[] {
-        return this.#aliases;
-    }
+
 
 
 }

--- a/src/Commands/Guild/Impl/unpinMessageCmdImpl.ts
+++ b/src/Commands/Guild/Impl/unpinMessageCmdImpl.ts
@@ -6,7 +6,7 @@ import { unpinMessageCmd } from "../Interf/unpinMessageCmd";
 
 export class UnpinMessageCmdImpl extends AbstractGuildCommand implements unpinMessageCmd {
 
-    protected _id: Collection<Snowflake, Snowflake> = new Collection(null);
+    id: Collection<Snowflake, Snowflake> = new Collection(null);
     readonly keyword = `unpin`;
     readonly guide = `Unpins a message`;
     readonly usage = `Right click on message => Apps => ${this.keyword}`;
@@ -15,7 +15,7 @@ export class UnpinMessageCmdImpl extends AbstractGuildCommand implements unpinMe
 
     static async init(): Promise<unpinMessageCmd> {
         const cmd = new UnpinMessageCmdImpl();
-        cmd._id = await fetchCommandID(cmd.keyword);
+        cmd.id = await fetchCommandID(cmd.keyword);
         return cmd;
     }
 

--- a/src/Commands/Managers/Impl/CommandManagerImpl.ts
+++ b/src/Commands/Managers/Impl/CommandManagerImpl.ts
@@ -210,7 +210,7 @@ export abstract class CommandManagerImpl implements CommandManager {
                         title: prefix + commandImpl.keyword,
                         description: '**usage:** ' + prefix + commandImpl.usage,
                         fields: [{ name: `Specified error  💥`, value: `• ${err}` }],
-                        footer: { text: commandImpl.getAliases().toString() },
+                        footer: { text: commandImpl.aliases.toString() },
                         color: "RED"
                     })
             ]
@@ -231,7 +231,7 @@ export abstract class CommandManagerImpl implements CommandManager {
                             title: providedCommand.keyword,
                             description: providedCommand.guide,
                             fields: [{ name: "Usage", value: providedCommand.usage, inline: true }],
-                            footer: { text: providedCommand.getAliases().toString() }
+                            footer: { text: providedCommand.aliases.toString() }
                         })
                     ]
             })

--- a/src/Commands/Managers/Impl/GlobalCommandManagerImpl.ts
+++ b/src/Commands/Managers/Impl/GlobalCommandManagerImpl.ts
@@ -29,7 +29,7 @@ export class GlobalCommandManagerImpl extends CommandManagerImpl implements Glob
                     guide: cmd.description,
                     global: true,
                     aliases: this.commands
-                        .find((cmds) => cmds.matchAliases(cmd.name))?.getAliases() ?? []
+                        .find((cmds) => cmds.matchAliases(cmd.name))?.aliases ?? []
 
                 })
             )

--- a/src/Commands/Managers/Impl/GuildCommandManagerImpl.ts
+++ b/src/Commands/Managers/Impl/GuildCommandManagerImpl.ts
@@ -36,7 +36,7 @@ export class GuildCommandManagerImpl extends CommandManagerImpl implements Guild
                     global: false,
                     guild_id: this.guildID,
                     aliases: this.commands
-                        .find((cmds) => cmds.matchAliases(cmd.name))?.getAliases() ?? []
+                        .find((cmds) => cmds.matchAliases(cmd.name))?.aliases ?? []
 
                 })
             ).values()]


### PR DESCRIPTION
This replaces Command getters with `readonly` access modifiers across the latter
