### PR TITLE
events: remove constructor and params

### DIFF
--- a/src/Events/AbstractEvent.ts
+++ b/src/Events/AbstractEvent.ts
@@ -5,15 +5,7 @@ import { GlobalCommandHandler } from "../Handlers/Global/GlobalCommandHandler";
 import GenericEvent from "./GenericEvent";
 
 export default abstract class AbstractEvent implements GenericEvent {
-    protected guilds: Guilds = null;
-    protected globalHandler: GlobalCommandHandler = null;
-    protected dmHandler: DmHandler = null;
     #name: keyof ClientEvents = null;
-    constructor(guilds: Guilds, globalHandler: GlobalCommandHandler, dmHandler: DmHandler) {
-        this.guilds = guilds;
-        this.globalHandler = globalHandler;
-        this.dmHandler = dmHandler;
-    }
 
     get name() {
         return this.#name;


### PR DESCRIPTION
- This PR removes unused class parameters, since they're imported (once constructed) from the `index` file
- Constructor also removed
closes #151 
